### PR TITLE
Updated permset Permitt midlertidig

### DIFF
--- a/force-app/apps/base/permissionsets/Arbeidsgiver_permittering_midlertidig.permissionset-meta.xml
+++ b/force-app/apps/base/permissionsets/Arbeidsgiver_permittering_midlertidig.permissionset-meta.xml
@@ -437,6 +437,10 @@
         <visibility>Visible</visibility>
     </tabSettings>
     <tabSettings>
+        <tab>standard-Account</tab>
+        <visibility>Available</visibility>
+    </tabSettings>
+    <tabSettings>
         <tab>standard-Dashboard</tab>
         <visibility>Available</visibility>
     </tabSettings>


### PR DESCRIPTION
To include Account as available tab, in order to make search results for account vissible.