### PR TITLE
Added short description back as read only

### DIFF
--- a/force-app/functionality/customOpportunity/layouts/CustomOpportunity__c-Inclusion Page Layout.layout-meta.xml
+++ b/force-app/functionality/customOpportunity/layouts/CustomOpportunity__c-Inclusion Page Layout.layout-meta.xml
@@ -83,6 +83,10 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>TAG_Short_Description__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>Notes__c</field>
             </layoutItems>
         </layoutColumns>
@@ -192,7 +196,7 @@
     <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
     <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
     <summaryLayout>
-        <masterLabel>00h3E000001r3gF</masterLabel>
+        <masterLabel>00h1j000001MmQk</masterLabel>
         <sizeX>4</sizeX>
         <sizeY>0</sizeY>
         <summaryLayoutStyle>Default</summaryLayoutStyle>

--- a/force-app/main/default/permissionsets/Arbeidsgiver_opportunity.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Arbeidsgiver_opportunity.permissionset-meta.xml
@@ -127,7 +127,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>true</editable>
+        <editable>false</editable>
         <field>CustomOpportunity__c.TAG_Short_Description__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Added short description on custom opportunity back to page layout as read only. So that users can copy over text to new note field.