### PR TITLE
TOLK-1496: Oppdatert valideringsregel så den kun gjelder RecordType ArbeidsgiverEvent

### DIFF
--- a/force-app/main/default/objects/Event/validationRules/No_person_information_added.validationRule-meta.xml
+++ b/force-app/main/default/objects/Event/validationRules/No_person_information_added.validationRule-meta.xml
@@ -2,7 +2,7 @@
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>No_person_information_added</fullName>
     <active>true</active>
-    <errorConditionFormula>AND( TAG_NoPersonInformation__c = FALSE, 	$Permission.Arbeidsgiver = TRUE, OR( ISBLANK(  RecordTypeId  ),   RecordType.DeveloperName = &apos;ArbeidsgiverEvent&apos; ) )</errorConditionFormula>
+    <errorConditionFormula>AND(TAG_NoPersonInformation__c = FALSE, $Permission.Arbeidsgiver = TRUE, RecordType.DeveloperName = &apos;ArbeidsgiverEvent&apos;)</errorConditionFormula>
     <errorDisplayField>TAG_NoPersonInformation__c</errorDisplayField>
     <errorMessage>Du må bekrefte at notatet ikke inneholder personsensitive opplysninger</errorMessage>
 </ValidationRule>


### PR DESCRIPTION
Vi har slitt en del med Outlook-integrasjonene og har funnet ut at problemet stammer fra denne valideringsregelen. Det virker som denne trigger i integrasjonene når man skal synke events fra Outlook til Salesforce. Når jeg endret den til å bare trigge på 
Record Type'en ArbeidsgiverEvent, ser det ut til å ha løst problemet.

https://jira.adeo.no/browse/TOLK-1496