### PR TITLE
Updated Script and recommended extensions.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
         "salesforce.salesforcedx-vscode",
         "aaron-bond.better-comments",
         "ChakrounAnas.turbo-console-log",
-        "CoenraadS.bracket-pair-colorizer-2",
         "dbaeumer.vscode-eslint",
         "donjayamanne.githistory",
         "eamodio.gitlens",

--- a/bin/install-scratch.bat
+++ b/bin/install-scratch.bat
@@ -75,7 +75,7 @@ call :checkForError
 @echo:
 
 echo Opening org...
-cmd.exe /c sfdx force:org:open
+cmd.exe /c sfdx force:org:open --path "lightning/app/c__TAG_NAV_default"
 @echo:
 
 rem Report install success if no error

--- a/bin/install-scratch.sh
+++ b/bin/install-scratch.sh
@@ -41,12 +41,101 @@ sfdx force:user:permset:assign -n Arbeidsgiver_base
 sfdx force:user:permset:assign -n Arbeidsgiver_contract
 sfdx force:user:permset:assign -n Arbeidsgiver_opportunity
 sfdx force:user:permset:assign -n Arbeidsgiver_temporaryLayoffs
+sfdx force:user:permset:assign -n ArbeidsgiverFia
+sfdx force:user:permset:assign -n ArbeidsgiverStillinger
 sfdx force:user:permset:assign -n CRM_LoginFlow
+echo ""
+
+# Creating temporary folder for test data files.
+echo "Moving test data to temp folder..."
+mkdir -p dummy-data/temp
+cp -r dummy-data/activityTimeline dummy-data/temp
+cp -r dummy-data/tag dummy-data/temp
+echo ""
+
+# Getting the Record Types from the new scratch org.
+echo "Getting Record Types..."
+sfdx force:data:soql:query --query "SELECT Id, SobjectType, DeveloperName FROM RecordType WHERE IsActive=true ORDER BY SObjectType, DeveloperName" --resultformat json > dummy-data/temp/RecordTypes.json
+echo ""
+
+# Prepering Activity Timeline test data by replacing RecordType placeholders with correct Ids.
+echo "Prepering Activity Timeline test data..."
+echo "Prepering Account test data..."
+for p in $(jq '.result.records[] | select(.SobjectType=="Account") | .DeveloperName' dummy-data/temp/RecordTypes.json);
+do
+    minTest=$(sed -e 's/^"//' -e 's/"$//' <<<"$p");
+    replace="\$R{RecordType.Account.$(sed -e 's/^"//' -e 's/"$//' <<<"$p")}"
+    replacewith=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.result.records[] | select(.SobjectType=="Account" and .DeveloperName=="'$minTest'") | .Id' dummy-data/temp/RecordTypes.json)");
+    sed -i "" "s/$replace/$replacewith/g" "dummy-data/temp/activityTimeline/Account.json"
+done
+echo ""
+
+echo "Prepering Custom Opportunities test data..."
+for p in $(jq '.result.records[] | select(.SobjectType=="CustomOpportunity__c") | .DeveloperName' dummy-data/temp/RecordTypes.json);
+do
+    minTest=$(sed -e 's/^"//' -e 's/"$//' <<<"$p");
+    replace="\$R{RecordType.CustomOpportunity__c.$(sed -e 's/^"//' -e 's/"$//' <<<"$p")}"
+    replacewith=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.result.records[] | select(.SobjectType=="CustomOpportunity__c" and .DeveloperName=="'$minTest'") | .Id' dummy-data/temp/RecordTypes.json)");
+    sed -i "" "s/$replace/$replacewith/g" "dummy-data/temp/activityTimeline/CustomOpportunities.json"
+done
+echo ""
+echo "Activity Timeline test data prepared..."
+echo ""
+
+# Prepering Tag test data by replacing RecordType placeholders with correct Ids.
+echo "Prepering Tag test data..."
+echo "Prepering Account test data..."
+for p in $(jq '.result.records[] | select(.SobjectType=="Account") | .DeveloperName' dummy-data/temp/RecordTypes.json);
+do
+    minTest=$(sed -e 's/^"//' -e 's/"$//' <<<"$p");
+    replace="\$R{RecordType.Account.$(sed -e 's/^"//' -e 's/"$//' <<<"$p")}"
+    replacewith=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.result.records[] | select(.SobjectType=="Account" and .DeveloperName=="'$minTest'") | .Id' dummy-data/temp/RecordTypes.json)");
+    sed -i "" "s/$replace/$replacewith/g" "dummy-data/temp/tag/Accounts-B.json"
+done
+
+for p in $(jq '.result.records[] | select(.SobjectType=="Account") | .DeveloperName' dummy-data/temp/RecordTypes.json);
+do
+    minTest=$(sed -e 's/^"//' -e 's/"$//' <<<"$p");
+    replace="\$R{RecordType.Account.$(sed -e 's/^"//' -e 's/"$//' <<<"$p")}"
+    replacewith=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.result.records[] | select(.SobjectType=="Account" and .DeveloperName=="'$minTest'") | .Id' dummy-data/temp/RecordTypes.json)");
+    sed -i "" "s/$replace/$replacewith/g" "dummy-data/temp/tag/Accounts-J.json"
+done
+
+for p in $(jq '.result.records[] | select(.SobjectType=="Account") | .DeveloperName' dummy-data/temp/RecordTypes.json);
+do
+    minTest=$(sed -e 's/^"//' -e 's/"$//' <<<"$p");
+    replace="\$R{RecordType.Account.$(sed -e 's/^"//' -e 's/"$//' <<<"$p")}"
+    replacewith=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.result.records[] | select(.SobjectType=="Account" and .DeveloperName=="'$minTest'") | .Id' dummy-data/temp/RecordTypes.json)");
+    sed -i "" "s/$replace/$replacewith/g" "dummy-data/temp/tag/Accounts-O.json"
+done
+echo ""
+
+echo "Prepering Custom Opportunities test data..."
+for p in $(jq '.result.records[] | select(.SobjectType=="CustomOpportunity__c") | .DeveloperName' dummy-data/temp/RecordTypes.json);
+do
+    minTest=$(sed -e 's/^"//' -e 's/"$//' <<<"$p");
+    replace="\$R{RecordType.CustomOpportunity__c.$(sed -e 's/^"//' -e 's/"$//' <<<"$p")}"
+    replacewith=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.result.records[] | select(.SobjectType=="CustomOpportunity__c" and .DeveloperName=="'$minTest'") | .Id' dummy-data/temp/RecordTypes.json)");
+    sed -i "" "s/$replace/$replacewith/g" "dummy-data/temp/tag/CustomOpportunities.json"
+done
+echo ""
+
+echo "Tag test data prepared..."
+echo ""
+
+# Inserting the prepared test data
+echo "Inserting test data..."
+sfdx force:data:tree:import -p  dummy-data/temp/activityTimeline/plan.json
+sfdx force:data:tree:import -p  dummy-data/temp/tag/plan.json
+echo ""
+
+echo "Removing temporary files..."
+rm -rf dummy-data/temp
 echo ""
 
 
 echo "Opening org..." && \
-sfdx force:org:open
+sfdx force:org:open --path "lightning/app/c__TAG_NAV_default"
 echo ""
 
 


### PR DESCRIPTION
Updated the bash script used by Mac and Linux to resolve the Record Type place holders used in the dummy data. Added the URL path for the "Arbeidsgiver" app to the open org command in both bash and batch scripts. Removed a deprecated VS Code extension recommendation.