### PR TITLE
Removed picklist values from record type

### DIFF
--- a/force-app/main/default/objects/NavTask__c/recordTypes/Employer.recordType-meta.xml
+++ b/force-app/main/default/objects/NavTask__c/recordTypes/Employer.recordType-meta.xml
@@ -80,19 +80,11 @@
             <fullName>Rekrutteringsoppdrag</fullName>
             <default>false</default>
         </values>
-        <values>
-            <fullName>Tiltaksøkonomi</fullName>
-            <default>false</default>
-        </values>
     </picklistValues>
     <picklistValues>
         <picklist>CRM_Theme__c</picklist>
         <values>
             <fullName>Forebygge sykefravær og redusere frafall</fullName>
-            <default>false</default>
-        </values>
-        <values>
-            <fullName>Nedbemanne</fullName>
             <default>false</default>
         </values>
         <values>


### PR DESCRIPTION
Ønske fra Arb.g. telefonen:
Tema "Nedbemmaning" skal fjernes
Gjelder verdi "Tiltaksøkonomi" under tema "Rekruttere og inkludere" Disse er ikke i bruk og skal ikke brukes da referatene raskt inkluderer navn på personer og bryter med personvernsprinsippene. Konkludert av vår fagkoordinator på området