### PR TITLE
timeline-metadatatypes and removed filter

### DIFF
--- a/.sf/config.json
+++ b/.sf/config.json
@@ -1,4 +1,3 @@
 {
-  "target-dev-hub": "DevHub",
-  "target-org": "impaktrapport"
+  "target-org": "arbeidsgiver-base"
 }

--- a/force-app/main/default/customMetadata/TimelineParent.IACase_Task_Call.md-meta.xml
+++ b/force-app/main/default/customMetadata/TimelineParent.IACase_Task_Call.md-meta.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>IACase &lt;= Task (Call)</label>
+    <protected>false</protected>
+    <values>
+        <field>AppAPIName__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConfigId__c</field>
+        <value xsi:type="xsd:string">TAG_NAV_default</value>
+    </values>
+    <values>
+        <field>CreateableObject_Checkbox__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>CreateableObject_NoOverride__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsActive__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsMacro__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>SObjectAssigneeId__c</field>
+        <value xsi:type="xsd:string">OwnerId</value>
+    </values>
+    <values>
+        <field>SObjectParent__c</field>
+        <value xsi:type="xsd:string">IACase__c</value>
+    </values>
+    <values>
+        <field>SObjectRelationshipField__c</field>
+        <value xsi:type="xsd:string">WhatId</value>
+    </values>
+    <values>
+        <field>Timeline_Child__c</field>
+        <value xsi:type="xsd:string">TAG_Task_Call</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/TimelineParent.IACase_Task_Email.md-meta.xml
+++ b/force-app/main/default/customMetadata/TimelineParent.IACase_Task_Email.md-meta.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>IACase &lt;= Task (Email)</label>
+    <protected>false</protected>
+    <values>
+        <field>AppAPIName__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConfigId__c</field>
+        <value xsi:type="xsd:string">TAG_NAV_default</value>
+    </values>
+    <values>
+        <field>CreateableObject_Checkbox__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>CreateableObject_NoOverride__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsActive__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsMacro__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>SObjectAssigneeId__c</field>
+        <value xsi:type="xsd:string">OwnerId</value>
+    </values>
+    <values>
+        <field>SObjectParent__c</field>
+        <value xsi:type="xsd:string">IACase__c</value>
+    </values>
+    <values>
+        <field>SObjectRelationshipField__c</field>
+        <value xsi:type="xsd:string">WhatId</value>
+    </values>
+    <values>
+        <field>Timeline_Child__c</field>
+        <value xsi:type="xsd:string">TAG_Task_Email</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/customMetadata/TimelineParent.IACase_Task_Sms.md-meta.xml
+++ b/force-app/main/default/customMetadata/TimelineParent.IACase_Task_Sms.md-meta.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <label>IACase &lt;= Task (SMS)</label>
+    <protected>false</protected>
+    <values>
+        <field>AppAPIName__c</field>
+        <value xsi:nil="true"/>
+    </values>
+    <values>
+        <field>ConfigId__c</field>
+        <value xsi:type="xsd:string">TAG_NAV_default</value>
+    </values>
+    <values>
+        <field>CreateableObject_Checkbox__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>CreateableObject_NoOverride__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsActive__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>IsMacro__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>
+    <values>
+        <field>SObjectAssigneeId__c</field>
+        <value xsi:type="xsd:string">OwnerId</value>
+    </values>
+    <values>
+        <field>SObjectParent__c</field>
+        <value xsi:type="xsd:string">IACase__c</value>
+    </values>
+    <values>
+        <field>SObjectRelationshipField__c</field>
+        <value xsi:type="xsd:string">WhatId</value>
+    </values>
+    <values>
+        <field>Timeline_Child__c</field>
+        <value xsi:type="xsd:string">TAG_Task_SMS</value>
+    </values>
+</CustomMetadata>

--- a/force-app/main/default/flexipages/IA_Case_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/IA_Case_Record_Page.flexipage-meta.xml
@@ -211,7 +211,7 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
-                    <value>Information</value>
+                    <value>Informasjon</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
                 <identifier>flexipage_fieldSection</identifier>
@@ -229,17 +229,10 @@
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>label</name>
-                    <value>System Information</value>
+                    <value>System Informasjon</value>
                 </componentInstanceProperties>
                 <componentName>flexipage:fieldSection</componentName>
                 <identifier>flexipage_fieldSection2</identifier>
-                <visibilityRule>
-                    <criteria>
-                        <leftValue>{!Record.Name}</leftValue>
-                        <operator>EQUAL</operator>
-                        <rightValue>æ</rightValue>
-                    </criteria>
-                </visibilityRule>
             </componentInstance>
         </itemInstances>
         <itemInstances>


### PR DESCRIPTION
Metadatatypes for timeline on ia-case: call, sms and email created. Removed dumb filter on system information.
Some translation changes on flexipage