### PR TITLE
Update WorkplaceCity__c.field-meta.xml

### DIFF
--- a/force-app/functionality/arbeidsplassen/objects/JobPosting__c/fields/WorkplaceCity__c.field-meta.xml
+++ b/force-app/functionality/arbeidsplassen/objects/JobPosting__c/fields/WorkplaceCity__c.field-meta.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>WorkplaceCity__c</fullName>
+    <deprecated>false</deprecated>
     <description>The cities where the job is located.</description>
     <externalId>false</externalId>
     <label>Workplace City</label>
-    <length>255</length>
-    <required>false</required>
+    <length>10000</length>
     <trackTrending>false</trackTrending>
-    <type>Text</type>
-    <unique>false</unique>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
 </CustomField>


### PR DESCRIPTION
update workplaceCity__c from text field to long text field. New length is 10000 chars and 3 lines visible as was standard for the other long text fields for the jobposting object