### PR TITLE
New button for contract on account

### DIFF
--- a/force-app/main/default/objects/Contract__c/webLinks/New_Employer_Agreement.webLink-meta.xml
+++ b/force-app/main/default/objects/Contract__c/webLinks/New_Employer_Agreement.webLink-meta.xml
@@ -11,5 +11,5 @@
     <openType>sidebar</openType>
     <protected>false</protected>
     <requireRowSelection>true</requireRowSelection>
-    <url>/lightning/o/Contract__c/new?defaultFieldValues=RecordTypeId={0125t000000Jtl9AAC}</url>
+    <url>/lightning/o/Contract__c/new?defaultFieldValues=RecordTypeId={0127U000000CgbDQAS}</url>
 </WebLink>


### PR DESCRIPTION
Fixed bug with wrong recordtype id in prod. that enabled user to add also measure type contracts.