### PR TITLE
Layout justering og nytt felt med fia link

### DIFF
--- a/.sf/config.json
+++ b/.sf/config.json
@@ -1,3 +1,3 @@
 {
-  "target-org": "arbeidsgiver-base"
+    "target-org": "arbeidsgiver-base"
 }

--- a/force-app/main/default/flexipages/IA_Case_Record_Page.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/IA_Case_Record_Page.flexipage-meta.xml
@@ -181,7 +181,88 @@
             <componentInstance>
                 <componentInstanceProperties>
                     <name>decorate</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>richTextValue</name>
+                    <value>&lt;p&gt;&lt;strong style=&quot;font-size: 18px;&quot;&gt;Fullførte behovsvurderinger&lt;/strong&gt;&lt;/p&gt;</value>
+                </componentInstanceProperties>
+                <componentName>flexipage:richText</componentName>
+                <identifier>flexipage_richText2</identifier>
+                <visibilityRule>
+                    <criteria>
+                        <leftValue>{!$Client.formFactor}</leftValue>
+                        <operator>EQUAL</operator>
+                        <rightValue>Large</rightValue>
+                    </criteria>
+                </visibilityRule>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>actionNames</name>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>adminFilters</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>Type__c|EQUALS|[&quot;Assessment&quot;]</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>maxRecordsToDisplay</name>
+                    <value>10</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>parentFieldApiName</name>
+                    <value>IACase__c.Id</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListApiName</name>
+                    <value>IA_Deliveries__r</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListDisplayType</name>
+                    <value>ADVGRID</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListFieldAliases</name>
+                    <valueList>
+                        <valueListItems>
+                            <value>CompletedDate__c</value>
+                        </valueListItems>
+                        <valueListItems>
+                            <value>FiaLink__c</value>
+                        </valueListItems>
+                    </valueList>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>relatedListLabel</name>
+                    <value>Fullførte Behovsvurderinger i Fia</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>showActionBar</name>
                     <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>sortFieldAlias</name>
+                    <value>CompletedDate__c</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>sortFieldOrder</name>
+                    <value>Descending</value>
+                </componentInstanceProperties>
+                <componentName>lst:dynamicRelatedList</componentName>
+                <identifier>lst_dynamicRelatedList5</identifier>
+            </componentInstance>
+        </itemInstances>
+        <itemInstances>
+            <componentInstance>
+                <componentInstanceProperties>
+                    <name>decorate</name>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>richTextValue</name>
@@ -573,96 +654,6 @@
                         <leftValue>{!$Client.formFactor}</leftValue>
                         <operator>NE</operator>
                         <rightValue>Small</rightValue>
-                    </criteria>
-                </visibilityRule>
-            </componentInstance>
-        </itemInstances>
-        <itemInstances>
-            <componentInstance>
-                <componentInstanceProperties>
-                    <name>actionNames</name>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>adminFilters</name>
-                    <valueList>
-                        <valueListItems>
-                            <value>Type__c|EQUALS|[&quot;Assessment&quot;]</value>
-                        </valueListItems>
-                    </valueList>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>maxRecordsToDisplay</name>
-                    <value>3</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>parentFieldApiName</name>
-                    <value>IACase__c.Id</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>relatedListApiName</name>
-                    <value>IA_Deliveries__r</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>relatedListDisplayType</name>
-                    <value>CARD</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>relatedListFieldAliases</name>
-                    <valueList>
-                        <valueListItems>
-                            <value>CompletedDate__c</value>
-                        </valueListItems>
-                    </valueList>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>relatedListLabel</name>
-                    <value>Fullførte Behovsvurderinger</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>showActionBar</name>
-                    <value>false</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>sortFieldAlias</name>
-                    <value>CompletedDate__c</value>
-                </componentInstanceProperties>
-                <componentInstanceProperties>
-                    <name>sortFieldOrder</name>
-                    <value>Descending</value>
-                </componentInstanceProperties>
-                <componentName>lst:dynamicRelatedList</componentName>
-                <identifier>lst_dynamicRelatedList5</identifier>
-                <visibilityRule>
-                    <booleanFilter>1 OR 2 OR 3 OR 4 OR 5 OR 6</booleanFilter>
-                    <criteria>
-                        <leftValue>{!$User.Email}</leftValue>
-                        <operator>EQUAL</operator>
-                        <rightValue>tonje.karidotter.okland@nav.no</rightValue>
-                    </criteria>
-                    <criteria>
-                        <leftValue>{!$User.Email}</leftValue>
-                        <operator>EQUAL</operator>
-                        <rightValue>andre.colle@nav.no</rightValue>
-                    </criteria>
-                    <criteria>
-                        <leftValue>{!$User.Email}</leftValue>
-                        <operator>EQUAL</operator>
-                        <rightValue>gisle.stenseng@nav.no</rightValue>
-                    </criteria>
-                    <criteria>
-                        <leftValue>{!$User.Email}</leftValue>
-                        <operator>EQUAL</operator>
-                        <rightValue>martin.ingeberg@nav.no</rightValue>
-                    </criteria>
-                    <criteria>
-                        <leftValue>{!$User.Email}</leftValue>
-                        <operator>EQUAL</operator>
-                        <rightValue>piotr.szostak@nav.no</rightValue>
-                    </criteria>
-                    <criteria>
-                        <leftValue>{!$User.Email}</leftValue>
-                        <operator>EQUAL</operator>
-                        <rightValue>silje.olsen@nav.no</rightValue>
                     </criteria>
                 </visibilityRule>
             </componentInstance>

--- a/force-app/main/default/layouts/IADelivery__c-IA Delivery Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/IADelivery__c-IA Delivery Layout.layout-meta.xml
@@ -42,6 +42,10 @@
                 <behavior>Edit</behavior>
                 <field>DeliveryCreatedByUser__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>FiaLink__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/force-app/main/default/objects/IADelivery__c/fields/FiaLink__c.field-meta.xml
+++ b/force-app/main/default/objects/IADelivery__c/fields/FiaLink__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>FiaLink__c</fullName>
+    <externalId>false</externalId>
+    <formula>/* https://fia.(&lt;ansatt.dev.&gt;)nav.no/virksomhet/&lt;orgnr&gt;/?fane=kartlegging&amp;kartleggingId=&lt;behovsvurderingId&gt; */
+HYPERLINK(&quot;https://fia.nav.no/virksomhet/&quot; &amp; IACase__r.Account__r.INT_OrganizationNumber__c &amp; &quot;/?fane=kartlegging&amp;kartleggingId=&quot; &amp; Name, &quot;Se behovsvurdering i Fia&quot;)</formula>
+    <label>Link</label>
+    <required>false</required>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/permissionsets/Arbeidsgiver_IA.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Arbeidsgiver_IA.permissionset-meta.xml
@@ -112,6 +112,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>IADelivery__c.FiaLink__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>IADelivery__c.IACase__c</field>
         <readable>true</readable>
     </fieldPermissions>
@@ -133,6 +138,11 @@
     <fieldPermissions>
         <editable>false</editable>
         <field>IADelivery__c.Status__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>IADelivery__c.Type__c</field>
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>

--- a/force-app/unpackagable/permissionsets/Admin_Base.permissionset-meta.xml
+++ b/force-app/unpackagable/permissionsets/Admin_Base.permissionset-meta.xml
@@ -322,6 +322,11 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
+        <field>IADelivery__c.FiaLink__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>false</editable>
         <field>IADelivery__c.JSONPayload__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Nytt felt med direktelink til behovsvurdering, Link__c. 
Lesetilgang i permission set "Arbeidsgiver - IA"  for felt Link__c og Type__c (Behovsvurdering, Leveranse).
Lesetilgang i "Arbeidsgiver - Base Permissions" for Link__c.

Justert related list på IA Sak:
- Viser opptil 10 behovsvurderinger.
- Dato sortering.
- Lagt til kolonnen med fia link.
- Fjernet visibility filter som kun gjorde den synlig for vårt team.
![image](https://github.com/user-attachments/assets/ce531750-3c45-43a0-901c-3e61fbaeff1e)