### PR TITLE
Removed new button form timeline on contact

### DIFF
--- a/force-app/main/default/flexipages/TAG_ContactRecordPage.flexipage-meta.xml
+++ b/force-app/main/default/flexipages/TAG_ContactRecordPage.flexipage-meta.xml
@@ -223,8 +223,19 @@
                     <value>3</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
+                    <name>buttonIsHidden</name>
+                    <value>true</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
                     <name>configId</name>
                     <value>TAG_NAV_default</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>customEmptySubtitle</name>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>filterIsActive</name>
+                    <value>false</value>
                 </componentInstanceProperties>
                 <componentInstanceProperties>
                     <name>headerIcon</name>
@@ -237,6 +248,27 @@
                 <componentInstanceProperties>
                     <name>headerTitleNorwegian</name>
                     <value>Aktiviteter</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>hideMyActivitiesFilter</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>includeAmountInTitle</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>logEvent</name>
+                    <value>false</value>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>picklistFilter1Label</name>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>picklistFilter2Label</name>
+                </componentInstanceProperties>
+                <componentInstanceProperties>
+                    <name>timelineParentField</name>
                 </componentInstanceProperties>
                 <componentName>timeline</componentName>
                 <identifier>timeline</identifier>


### PR DESCRIPTION
The related to is now read only and this causes problems. We also get problems in reportering etc. when activities is added directly on contact and not on account and then related to contact.