### PR TITLE
Justering på flows som sender kontraktvarsel

### DIFF
--- a/force-app/main/default/flows/TAG_Contract_Old_Agreement_Type_Notification.flow-meta.xml
+++ b/force-app/main/default/flows/TAG_Contract_Old_Agreement_Type_Notification.flow-meta.xml
@@ -177,6 +177,11 @@
         <dataType>String</dataType>
         <expression>LEFT({!$Api.Partner_Server_URL_340},FIND(&quot;/services&quot;, {!$Api.Partner_Server_URL_340})) &amp; &apos;lightning/o/Contract__c/list?filterName=Mine_bedriftsavtaler_Gammel_type&apos;</expression>
     </formulas>
+    <formulas>
+        <name>x13_days_ago</name>
+        <dataType>DateTime</dataType>
+        <expression>NOW() - 13</expression>
+    </formulas>
     <interviewLabel>TAG Contract Notify Old Agreement Type {!$Flow.CurrentDateTime}</interviewLabel>
     <label>TAG Contract Old Agreement Type Notification</label>
     <loops>
@@ -221,7 +226,7 @@
         <connector>
             <targetReference>Check_if_contracts_was_found</targetReference>
         </connector>
-        <filterLogic>1 AND (2 OR 3 OR 4 ) AND 5 AND 6 AND 7</filterLogic>
+        <filterLogic>1 AND (2 OR 3 OR 4 ) AND 5 AND 6 AND 7 AND (8 OR 9)</filterLogic>
         <filters>
             <field>TAG_InternalContact__c</field>
             <operator>IsNull</operator>
@@ -269,6 +274,20 @@
             <operator>EqualTo</operator>
             <value>
                 <elementReference>Get_recordtype.Id</elementReference>
+            </value>
+        </filters>
+        <filters>
+            <field>TAG_Expiration_Reminder_Send_Date__c</field>
+            <operator>IsNull</operator>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </filters>
+        <filters>
+            <field>TAG_Expiration_Reminder_Send_Date__c</field>
+            <operator>LessThanOrEqualTo</operator>
+            <value>
+                <elementReference>x13_days_ago</elementReference>
             </value>
         </filters>
         <getFirstRecordOnly>false</getFirstRecordOnly>
@@ -321,12 +340,12 @@
         </connector>
         <schedule>
             <frequency>Weekly</frequency>
-            <startDate>2025-09-29</startDate>
-            <startTime>09:00:00.000Z</startTime>
+            <startDate>2025-10-06</startDate>
+            <startTime>08:00:00.000Z</startTime>
         </schedule>
         <triggerType>Scheduled</triggerType>
     </start>
-    <status>Draft</status>
+    <status>Active</status>
     <subflows>
         <name>Flow_Create_Application_Log_Flow_1</name>
         <label>Flow Create Application Log Flow 1</label>

--- a/force-app/main/default/flows/TAG_Contract_update_reminder.flow-meta.xml
+++ b/force-app/main/default/flows/TAG_Contract_update_reminder.flow-meta.xml
@@ -172,6 +172,11 @@
         <dataType>String</dataType>
         <expression>LEFT({!$Api.Partner_Server_URL_340},FIND(&quot;/services&quot;, {!$Api.Partner_Server_URL_340})) &amp; &apos;lightning/o/Contract__c/list?filterName=Mine_avtaler_til_forfall&apos;</expression>
     </formulas>
+    <formulas>
+        <name>x13_days_ago</name>
+        <dataType>DateTime</dataType>
+        <expression>NOW() - 13</expression>
+    </formulas>
     <interviewLabel>TAG {!$Flow.CurrentDateTime}</interviewLabel>
     <label>TAG Contract update reminder</label>
     <loops>
@@ -216,12 +221,26 @@
         <connector>
             <targetReference>Check_if_contracts_was_found</targetReference>
         </connector>
-        <filterLogic>and</filterLogic>
+        <filterLogic>1 AND (2 OR 3)</filterLogic>
         <filters>
             <field>TAG_Expiration_Reminder__c</field>
             <operator>EqualTo</operator>
             <value>
                 <booleanValue>true</booleanValue>
+            </value>
+        </filters>
+        <filters>
+            <field>TAG_Expiration_Reminder_Send_Date__c</field>
+            <operator>IsNull</operator>
+            <value>
+                <booleanValue>true</booleanValue>
+            </value>
+        </filters>
+        <filters>
+            <field>TAG_Expiration_Reminder_Send_Date__c</field>
+            <operator>LessThanOrEqualTo</operator>
+            <value>
+                <elementReference>x13_days_ago</elementReference>
             </value>
         </filters>
         <getFirstRecordOnly>false</getFirstRecordOnly>
@@ -246,12 +265,12 @@
         </connector>
         <schedule>
             <frequency>Weekly</frequency>
-            <startDate>2025-12-01</startDate>
-            <startTime>09:00:00.000Z</startTime>
+            <startDate>2025-09-16</startDate>
+            <startTime>08:00:00.000Z</startTime>
         </schedule>
         <triggerType>Scheduled</triggerType>
     </start>
-    <status>Draft</status>
+    <status>Active</status>
     <subflows>
         <name>Flow_Create_Application_Log_Flow_1</name>
         <label>Flow Create Application Log Flow 1</label>
@@ -330,7 +349,7 @@
         <description>Bedriftsavtale nærmer seg utløpsdato</description>
         <name>NotificationText</name>
         <isViewedAsPlainText>false</isViewedAsPlainText>
-        <text>&lt;p&gt;Hei,&lt;/p&gt;&lt;p&gt;Dette er et automatisk varsel fra Salesforce Arbeidsgiver.&lt;/p&gt;&lt;p&gt;Du mottar denne varslingen fordi du er registrert som ansvarlig for en eller flere bedriftsavtaler som nærmere seg utløpsdato.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Hva betyr dette?&lt;/strong&gt;&lt;/p&gt;&lt;p&gt;Bedriftsavtalene har mindre enn 2 måneder igjen til utløp og bør vurderes for enten forlenging eller avslutning. Det er viktig at disse avtalene følges opp i tide for å sikre kontinuitet i samarbeidet med arbeidsgiverne.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Hva må du gjøre?&lt;/strong&gt;&lt;/p&gt;&lt;ol&gt;&lt;li&gt;Gå til oversikten over avtaler som nærmer seg forfall: &lt;a href=&quot;{!updatePageUrl}&quot; rel=&quot;noopener noreferrer&quot; target=&quot;_blank&quot; style=&quot;color: rgb(11, 92, 171); background-color: rgb(255, 255, 255);&quot;&gt;&lt;strong&gt;Mine bedriftsavtaler nær utløpsdato&lt;/strong&gt;&lt;/a&gt;&lt;/li&gt;&lt;li&gt;Vurder hver avtale individuelt&lt;/li&gt;&lt;li&gt;Ta kontakt med arbeidsgiver for å avklare om avtalen skal forlenges&lt;/li&gt;&lt;li&gt;Oppdater avtalens status og eventuelt ny sluttdato i systemet&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Ved spørsmål om oppfølging av bedriftsavtaler, ta kontakt med din leder eller teamleder.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;Med vennlig hilsen&lt;/p&gt;&lt;p&gt;Nav Salesforce Arbeidsgiver&lt;/p&gt;</text>
+        <text>&lt;p&gt;Hei,&lt;/p&gt;&lt;p&gt;Dette er et automatisk varsel fra Salesforce Arbeidsgiver.&lt;/p&gt;&lt;p&gt;Du mottar denne varslingen fordi du er registrert som ansvarlig for en eller flere bedriftsavtaler som nærmer seg utløpsdato.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Hva betyr dette?&lt;/strong&gt;&lt;/p&gt;&lt;p&gt;Bedriftsavtalene har mindre enn 2 måneder igjen til utløp og bør vurderes for enten forlenging eller avslutning. Det er viktig at disse avtalene følges opp i tide for å sikre kontinuitet i samarbeidet med arbeidsgiverne.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;strong&gt;Hva må du gjøre?&lt;/strong&gt;&lt;/p&gt;&lt;ol&gt;&lt;li&gt;Gå til oversikten over avtaler som nærmer seg forfall: &lt;a href=&quot;{!updatePageUrl}&quot; rel=&quot;noopener noreferrer&quot; target=&quot;_blank&quot; style=&quot;color: rgb(11, 92, 171); background-color: rgb(255, 255, 255);&quot;&gt;&lt;strong&gt;Mine bedriftsavtaler nær utløpsdato&lt;/strong&gt;&lt;/a&gt;&lt;/li&gt;&lt;li&gt;Vurder hver avtale individuelt&lt;/li&gt;&lt;li&gt;Ta kontakt med arbeidsgiver for å avklare om avtalen skal forlenges&lt;/li&gt;&lt;li&gt;Oppdater avtalens status og eventuelt ny sluttdato i systemet&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Ved spørsmål om oppfølging av bedriftsavtaler, ta kontakt med din leder eller teamleder.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;Med vennlig hilsen&lt;/p&gt;&lt;p&gt;Nav Salesforce Arbeidsgiver&lt;/p&gt;</text>
     </textTemplates>
     <variables>
         <name>InternalContactEmails</name>

--- a/force-app/main/default/permissionsets/Admin_Base.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Admin_Base.permissionset-meta.xml
@@ -95,7 +95,7 @@
         <readable>true</readable>
     </fieldPermissions>
     <fieldPermissions>
-        <editable>false</editable>
+        <editable>true</editable>
         <field>Contract__c.TAG_Expiration_Reminder_Send_Date__c</field>
         <readable>true</readable>
     </fieldPermissions>


### PR DESCRIPTION
Rettet skrivefeil i e-post.
Flows kjøres ukentlig, men varsel sendes kun dersom det er 2 uker siden forrige varsel (sjekkes mot feltet TAG_Expiration_Reminder_Send_Date__c). Påminnelse om fornyelse sendes tirsdager kl 8, f.o.m. 16/9. Varsel om å oppdatere til nytt rammeverk sendes mandager kl 8, f.o.m. 6/10.